### PR TITLE
feat: make network check timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ This helps prevent many devices from running the task at the exact same time. Th
 ### DONOTRUNONMETERED
 Default value 1. Set `DONOTRUNONMETERED=0` to force WAU to run on metered connections. May add cellular data costs on shared connexion from smartphone for example.
 
+### NETWORKTIMEOUTSECONDS
+Maximum time in seconds WAU waits for an internet connection before aborting. Default value 300.
+
+### NETWORKRETRYINTERVALSECONDS
+Seconds between connection attempts while waiting for an internet connection. Default value 10.
+
 ### MAXLOGFILES
 Specify number of allowed log files.<br>
 Default is 3 out of 0-99:<br>

--- a/Sources/Winget-AutoUpdate/Winget-Upgrade.ps1
+++ b/Sources/Winget-AutoUpdate/Winget-Upgrade.ps1
@@ -172,7 +172,10 @@ Write-ToLog "Notification Level: $($WAUConfig.WAU_NotificationLevel). Notificati
 #endregion
 
 #Check network connectivity
-if (Test-Network) {
+$testNetworkParams = @{}
+if ($WAUConfig.WAU_NetworkTimeoutSeconds) { $testNetworkParams.TimeoutSeconds = $WAUConfig.WAU_NetworkTimeoutSeconds }
+if ($WAUConfig.WAU_NetworkRetryIntervalSeconds) { $testNetworkParams.RetryIntervalSeconds = $WAUConfig.WAU_NetworkRetryIntervalSeconds }
+if (Test-Network @testNetworkParams) {
 
     #Check prerequisites
     if ($true -eq $IsSystem) {


### PR DESCRIPTION
## Summary
- allow Test-Network to take configurable timeout and retry interval
- use Test-Connection with stopwatch-based timeout handling
- read network timeout settings from WAUConfig and document parameters

## Testing
- `pwsh -NoProfile -Command ". ./Sources/Winget-AutoUpdate/functions/Test-Network.ps1"` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a5abd50e148325a2c179fa2f58385a