### PR TITLE
Refactor winget queries to use JSON output

### DIFF
--- a/Sources/Winget-AutoUpdate/functions/Get-AppInfo.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Get-AppInfo.ps1
@@ -1,12 +1,12 @@
 #Get the winget App Information
 
 Function Get-AppInfo ($AppID) {
-    #Get AppID Info
-    $String = & $winget show $AppID --accept-source-agreements -s winget | Out-String
+    try {
+        $info = & $winget show $AppID --accept-source-agreements --output json | ConvertFrom-Json
+    }
+    catch {
+        return $null
+    }
 
-    #Search for Release Note info
-    $ReleaseNote = [regex]::match($String, "(?<=Release Notes Url: )(.*)(?=\n)").Groups[0].Value
-
-    #Return Release Note
-    return $ReleaseNote
+    return $info.ReleaseNotesUrl
 }

--- a/Sources/Winget-AutoUpdate/functions/Get-WingetOutdatedApps.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Get-WingetOutdatedApps.ps1
@@ -14,81 +14,44 @@ function Get-WingetOutdatedApps {
         [string]$AvailableVersion
     }
 
-    #Get list of available upgrades on winget format
+    #Get list of available upgrades in JSON format
     try {
-        $upgradeResult = & $Winget upgrade --source $src | Where-Object { $_ -notlike "   *" } | Out-String
+        $upgradeResult = & $Winget upgrade --source $src --output json | ConvertFrom-Json
     }
     catch {
         Write-ToLog "Error while recieving winget upgrade list: $_" "Red"
         $upgradeResult = $null
     }
 
-    #Start Conversion of winget format to an array. Check if "-----" exists (Winget Error Handling)
-    if (!($upgradeResult -match "-----")) {
-
+    if (-not $upgradeResult) {
         return "No update found. 'Winget upgrade' output:`n$upgradeResult"
-
     }
-    else {
 
-        #Split winget output to lines
-        $lines = $upgradeResult.Split([Environment]::NewLine) | Where-Object { $_ }
+    # Extract package list from JSON
+    $packages = $upgradeResult |
+        Select-Object -ExpandProperty Sources -ErrorAction SilentlyContinue |
+        Select-Object -ExpandProperty Packages -ErrorAction SilentlyContinue
 
-        # Find the line that starts with "------"
-        $fl = 0
-        while (-not $lines[$fl].StartsWith("-----")) {
-            $fl++
-        }
-
-        #Get header line
-        $fl = $fl - 1
-
-        #Get header titles [without remove separator]
-        $index = $lines[$fl] -split '(?<=\s)(?!\s)'
-
-        # Line $fl has the header, we can find char where we find ID and Version [and manage non latin characters]
-        $idStart = $($index[0] -replace '[\u4e00-\u9fa5]', '**').Length
-        $versionStart = $idStart + $($index[1] -replace '[\u4e00-\u9fa5]', '**').Length
-        $availableStart = $versionStart + $($index[2] -replace '[\u4e00-\u9fa5]', '**').Length
-
-        # Now cycle in real package and split accordingly
-        $upgradeList = @()
-        For ($i = $fl + 2; $i -lt $lines.Length; $i++) {
-            $line = $lines[$i] -replace "[\u2026]", " " #Fix "..." in long names
-            if ($line.StartsWith("-----")) {
-                #Get header line
-                $fl = $i - 1
-
-                #Get header titles [without remove separator]
-                $index = $lines[$fl] -split '(?<=\s)(?!\s)'
-
-                # Line $fl has the header, we can find char where we find ID and Version [and manage non latin characters]
-                $idStart = $($index[0] -replace '[\u4e00-\u9fa5]', '**').Length
-                $versionStart = $idStart + $($index[1] -replace '[\u4e00-\u9fa5]', '**').Length
-                $availableStart = $versionStart + $($index[2] -replace '[\u4e00-\u9fa5]', '**').Length
-            }
-            #(Alphanumeric | Literal . | Alphanumeric) - the only unique thing in common for lines with applications
-            if ($line -match "\w\.\w") {
-                $software = [Software]::new()
-                #Manage non latin characters
-                $nameDeclination = $($line.Substring(0, $idStart) -replace '[\u4e00-\u9fa5]', '**').Length - $line.Substring(0, $idStart).Length
-                $software.Name = $line.Substring(0, $idStart - $nameDeclination).TrimEnd()
-                $software.Id = $line.Substring($idStart - $nameDeclination, $versionStart - $idStart).TrimEnd()
-                $software.Version = $line.Substring($versionStart - $nameDeclination, $availableStart - $versionStart).TrimEnd()
-                $software.AvailableVersion = $line.Substring($availableStart - $nameDeclination).TrimEnd()
-                #add formatted soft to list
-                $upgradeList += $software
-            }
-        }
-
-        #If current user is not system, remove system apps from list
-        if ($IsSystem -eq $false) {
-            $SystemApps = Get-Content -Path "$WorkingDir\config\winget_system_apps.txt" -ErrorAction SilentlyContinue
-            $upgradeList = $upgradeList | Where-Object { $SystemApps -notcontains $_.Id }
-        }
-
-        return $upgradeList | Sort-Object { Get-Random }
-
+    if (-not $packages) {
+        return "No update found. 'Winget upgrade' output:`n$upgradeResult"
     }
+
+    # Map packages to Software objects
+    $upgradeList = foreach ($pkg in $packages) {
+        [Software]@{
+            Name            = $pkg.PackageName
+            Id              = $pkg.PackageIdentifier
+            Version         = $pkg.InstalledVersion
+            AvailableVersion = $pkg.AvailableVersion
+        }
+    }
+
+    #If current user is not system, remove system apps from list
+    if ($IsSystem -eq $false) {
+        $SystemApps = Get-Content -Path "$WorkingDir\config\winget_system_apps.txt" -ErrorAction SilentlyContinue
+        $upgradeList = $upgradeList | Where-Object { $SystemApps -notcontains $_.Id }
+    }
+
+    return $upgradeList | Sort-Object { Get-Random }
 
 }


### PR DESCRIPTION
## Summary
- Parse `winget upgrade` output as JSON in `Get-WingetOutdatedApps`
- Fetch release note URL from `winget show` JSON
- Use `winget search` JSON in installer GUI and handle structured results

## Testing
- ❌ `pwsh -NoLogo -NoProfile -Command "Invoke-ScriptAnalyzer -Path 'Sources/Winget-AutoUpdate/functions/Get-WingetOutdatedApps.ps1'"` (command not found)
- ⚠️ `apt-get update` (repository 403 errors)

------
https://chatgpt.com/codex/tasks/task_e_68a5abcda1148325b329db2a5523e985